### PR TITLE
Split actual and expected by line endings and compare the resulting arrays to fix tests on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -875,9 +875,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "mimic-fn": {

--- a/template/test/snapshot_test.ts
+++ b/template/test/snapshot_test.ts
@@ -7,7 +7,7 @@ import plugin from '..';
 import assert = require('assert');
 
 const splitStringByNewLine = (input: string): string[] => {
-    const splitted = input.match(/[^\r\n]+/g)
+    const splitted = input.split(/\r?\n/);
     return splitted ? splitted : [];
 } 
 

--- a/template/test/snapshot_test.ts
+++ b/template/test/snapshot_test.ts
@@ -6,6 +6,11 @@ import plugin from '..';
 
 import assert = require('assert');
 
+const splitStringByNewLine = (input: string): string[] => {
+    const splitted = input.match(/[^\r\n]+/g)
+    return splitted ? splitted : [];
+} 
+
 describe('PreProcess Snapshot testing', () => {
     const fixturesDir = path.join(__dirname, 'pre_snapshots');
     const inputFileName = 'input.json';
@@ -59,9 +64,9 @@ describe('PreProcess Snapshot testing', () => {
                 const expected = fs.readFileSync(expectedFilePath, {
                     encoding: 'utf-8',
                 });
-                assert.equal(
-                    actual,
-                    expected,
+                assert.deepEqual(
+                    splitStringByNewLine(actual),
+                    splitStringByNewLine(expected),
                     `
 ${fixtureDir}
 ${actual}
@@ -130,9 +135,9 @@ describe('PostProcess Snapshot testing', () => {
                 const expected = fs.readFileSync(expectedFilePath, {
                     encoding: 'utf-8',
                 });
-                assert.equal(
-                    actual,
-                    expected,
+                assert.deepEqual(
+                   splitStringByNewLine(actual),
+                   splitStringByNewLine(expected),
                     `
 ${fixtureDir}
 ${actual}


### PR DESCRIPTION
Before comparing expected and actual split by line breaks and compare arrays.

This works on my Windows machine. I tested this in my project, wasn't able to test it in the fork. Feel free to tell me what you think @horiuchi 

Fixed npm audit results